### PR TITLE
Fix bazel in CI precompile binaries

### DIFF
--- a/tools/package/main.rs
+++ b/tools/package/main.rs
@@ -56,7 +56,15 @@ fn main() {
             cmd.arg(format!("--output_user_root={bc}"));
         }
 
-        cmd.args(["build", "--compilation_mode", "opt", "--strip", "always", "--enable_bzlmod=false"]);
+        cmd.args([
+            "build",
+            "--compilation_mode",
+            "opt",
+            "--strip",
+            "always",
+            "--enable_bzlmod=false",
+            "--enable_workspace=true",
+        ]);
 
         cmd.args(BINARIES.iter().map(|b| format!(":{b}")));
         cmd.current_dir(cwd);


### PR DESCRIPTION
Without this we get:

```
ERROR: Error computing the main repository mapping: error loading package 'external': Both --enable_bzlmod and --enable_workspace are disabled, but one of them must be enabled to fetch external dependencies.
```