### PR TITLE
up version to what is published on crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 name = "spirv-tools"
 description = "Wrapper crate for SPIRV-Tools"
 repository = "https://github.com/rust-gpu/spirv-tools-rs"
-version = "0.10.0"
+version = "0.11.0"
 authors = ["Embark <opensource@embark-studios.com>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -31,7 +31,7 @@ use-installed-tools = [
 use-compiled-tools = ["spirv-tools-sys/use-compiled-tools"]
 
 [dependencies]
-spirv-tools-sys = { version = "0.8", path = "./spirv-tools-sys", default-features = false }
+spirv-tools-sys = { version = "0.9", path = "./spirv-tools-sys", default-features = false }
 # Used for parsing output when running binaries
 memchr = { version = "2.3", optional = true }
 tempfile = { version = "3.1", optional = true }

--- a/spirv-tools-sys/Cargo.toml
+++ b/spirv-tools-sys/Cargo.toml
@@ -2,7 +2,7 @@
 name = "spirv-tools-sys"
 description = "Wrapper crate for SPIRV-Tools"
 repository = "https://github.com/rust-gpu/spirv-tools-rs"
-version = "0.8.0"
+version = "0.9.0"
 authors = ["Embark <opensource@embark-studios.com>"]
 edition = "2021"
 # This is the same license for the underlying SPIRV-Tools code


### PR DESCRIPTION
I would like to tag that release, to fix the CI in rust-gpu