### PR TITLE
disable cpp warning `array-bounds` and `stringop-overflow`

### DIFF
--- a/spirv-tools-sys/build.rs
+++ b/spirv-tools-sys/build.rs
@@ -129,6 +129,8 @@ fn main() {
             .flag("-Wextra")
             .flag("-Wnon-virtual-dtor")
             .flag("-Wno-missing-field-initializers")
+            .flag("-Wno-stringop-overflow")
+            .flag("-Wno-array-bounds")
             .flag("-Werror")
             .flag("-std=c++17")
             .flag("-fno-exceptions")


### PR DESCRIPTION
closes https://github.com/Rust-GPU/rust-gpu/issues/370