### PR TITLE
nix: add `default.nix` for nix-shell

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,15 @@
+let
+  pkgs = import <nixpkgs> {};
+in with pkgs; stdenv.mkDerivation rec {
+  name = "spirv-tools";
+
+  # Workaround for https://github.com/NixOS/nixpkgs/issues/60919.
+  # NOTE(eddyb) needed only in debug mode (warnings about needing optimizations
+  # turn into errors due to `-Werror`, for at least `spirv-tools-sys`).
+  hardeningDisable = [ "fortify" ];
+
+  # Allow cargo to download crates (even inside `nix-shell --pure`).
+  SSL_CERT_FILE = "${cacert}/etc/ssl/certs/ca-bundle.crt";
+
+  nativeBuildInputs = [ rustup ];
+}


### PR DESCRIPTION
Copy of rust-gpu's `default.nix` with some extra graphics-related libs removed