### PR TITLE
ci: use `cargo publish --dry-run` to verify packaged crates

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -93,29 +93,24 @@ jobs:
           submodules: true
       - uses: EmbarkStudios/cargo-deny-action@v2
 
-  release-plz-dry-run:
-    name: Release-plz dry-run
+  release-dry-run:
+    name: Release dry-run
     runs-on: ubuntu-latest
-    permissions: {}
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ github.head_ref }}
-          fetch-depth: 0
-          persist-credentials: false
           submodules: true
-      - name: Run release-plz
-        uses: release-plz/action@v0.5
-        with:
-          dry_run: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: install rust-toolchain
+        run: echo "TARGET=$(rustc --print host-tuple)" >> "$GITHUB_ENV"
+      - name: cargo fetch --locked
+        run: cargo fetch --locked --target $TARGET
+      - run: cargo publish --dry-run
 
   # This allows us to have a single job we can branch protect on, rather than needing
   # to update the branch protection rules when the test matrix changes
   test_success:
     runs-on: ubuntu-24.04
-    needs: [lint, test, deny-check, release-plz-dry-run]
+    needs: [lint, test, deny-check, release-dry-run]
     # Hack for buggy GitHub Actions behavior with skipped checks: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/troubleshooting-required-status-checks#handling-skipped-but-required-checks
     if: ${{ always() }}
     steps:
@@ -125,7 +120,7 @@ jobs:
           [[ "${{ needs.lint.result }}" == "success" ]] || exit 1
           [[ "${{ needs.test.result }}" == "success" ]] || exit 1
           [[ "${{ needs.deny-check.result }}" == "success" ]] || exit 1
-          [[ "${{ needs.release-plz-dry-run.result }}" == "success" ]] || exit 1
+          [[ "${{ needs.release-dry-run.result }}" == "success" ]] || exit 1
 
 defaults:
   run:


### PR DESCRIPTION
* use `cargo package` instead of `release-plz` to verify packaged crates
  * [This failing action](https://github.com/Rust-GPU/spirv-tools-rs/actions/runs/24242281125/job/70779548714) shows missing headers lead to CI failure
* release-plz's `dry-run` doesn't work properly and randomly fails:

## release-plz dry-run problems

Half of the time, it succeeds with `Warning: release-plz release-pr failed with HTTP 422; continuing with no PRs created.`:
* https://github.com/Rust-GPU/spirv-tools-rs/actions/runs/24101495352/job/70394944864#step:3:287
* https://github.com/Rust-GPU/spirv-tools-rs/actions/runs/24129486666/job/70402246110#step:3:287

And the other half it just fails with:
```
ERROR failed to create ref refs/heads/release-plz-2026-04-09T18-06-58Z with sha 87c458454a0f5222e7d4d1bb8621a8aec8e28bdb

Caused by:
    0: Response body:
       {
         "documentation_url": "https://docs.github.com/rest/git/refs#create-a-reference",
         "message": "Resource not accessible by integration",
         "status": "403"
       }
    1: HTTP status client error (403 Forbidden) for url (https://api.github.com/repos/Rust-GPU/spirv-tools-rs/git/refs)
Error: failed to create ref refs/heads/release-plz-2026-04-09T18-06-58Z with sha 87c458454a0f5222e7d4d1bb8621a8aec8e28bdb
```
* https://github.com/Rust-GPU/spirv-tools-rs/actions/runs/24097047074/job/70298215853
* https://github.com/Rust-GPU/spirv-tools-rs/actions/runs/24205043710/job/70658560248

Rereading [the documentation](https://release-plz.dev/docs/github/input), it does state:
> the --dry-run flag is only added to the release command (the flag isn't added to the release-pr command).